### PR TITLE
vm -> flex

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,6 @@
 # [START runtime]
 runtime: ruby
-vm: true
+env: flex
 entrypoint: bundle exec ruby app.rb -p $PORT
 # [END runtime]
 


### PR DESCRIPTION
WARNING: Deployments using `vm: true` have been deprecated.  Please update your app.yaml to use `env: flex`. To learn more, please visit https://cloud.google.com/appengine/docs/flexible/migration.